### PR TITLE
Add previous and next links to the parts.

### DIFF
--- a/1. What is GraphQL.md
+++ b/1. What is GraphQL.md
@@ -50,4 +50,5 @@ The official site is here: [graphql.org](http://graphql.org/)
 We'll discuss them as we go through the series.
 
 <strike>Previous</strike>
+
 [Next](http://google.com) - Basic Query Syntax

--- a/1. What is GraphQL.md
+++ b/1. What is GraphQL.md
@@ -48,3 +48,6 @@ The official site is here: [graphql.org](http://graphql.org/)
  A GraphQL query can be ensured to be valid within a GraphQL type system at development time allowing the server to make guarantees about the response. This makes it easier to build high-quality client tools.
 
 We'll discuss them as we go through the series.
+
+<strike>Previous</strike>
+[Next](http://google.com) - Basic Query Syntax

--- a/1. What is GraphQL.md
+++ b/1. What is GraphQL.md
@@ -51,4 +51,4 @@ We'll discuss them as we go through the series.
 
 <strike>Previous</strike>
 
-[Next](http://google.com) - Basic Query Syntax
+[Next](2.%20Basic%20Query%20Syntax.md) - Basic Query Syntax

--- a/2. Basic Query Syntax.md
+++ b/2. Basic Query Syntax.md
@@ -102,4 +102,4 @@ However, if a query has no `arguments` or `directives` (we will discuss directiv
 
 [Previous](1.%20What%20is%20GraphQL.md) - What is GraphQL
 
-[Next](2.%20Basic%20Query%20Syntax.md) - Querying with Field Aliases and Fragments
+[Next](3.%20Querying%20with%20Field%20Aliases%20and%20Fragments.md) - Querying with Field Aliases and Fragments

--- a/2. Basic Query Syntax.md
+++ b/2. Basic Query Syntax.md
@@ -100,6 +100,6 @@ However, if a query has no `arguments` or `directives` (we will discuss directiv
 
 ```
 
-[Previous](http://google.com) - What is GraphQL
+[Previous](1. What is GraphQL.md) - What is GraphQL
 
-[Next](http://google.com) - Querying with Field Aliases and Fragments
+[Next](2. Basic Query Syntax.md) - Querying with Field Aliases and Fragments

--- a/2. Basic Query Syntax.md
+++ b/2. Basic Query Syntax.md
@@ -100,6 +100,6 @@ However, if a query has no `arguments` or `directives` (we will discuss directiv
 
 ```
 
-[Previous](1. What is GraphQL.md) - What is GraphQL
+[Previous](/1. What is GraphQL.md) - What is GraphQL
 
-[Next](2. Basic Query Syntax.md) - Querying with Field Aliases and Fragments
+[Next](/2. Basic Query Syntax.md) - Querying with Field Aliases and Fragments

--- a/2. Basic Query Syntax.md
+++ b/2. Basic Query Syntax.md
@@ -99,3 +99,6 @@ However, if a query has no `arguments` or `directives` (we will discuss directiv
 }
 
 ```
+
+[Previous](http://google.com) - What is GraphQL
+[Next](http://google.com) - Querying with Field Aliases and Fragments

--- a/2. Basic Query Syntax.md
+++ b/2. Basic Query Syntax.md
@@ -101,4 +101,5 @@ However, if a query has no `arguments` or `directives` (we will discuss directiv
 ```
 
 [Previous](http://google.com) - What is GraphQL
+
 [Next](http://google.com) - Querying with Field Aliases and Fragments

--- a/2. Basic Query Syntax.md
+++ b/2. Basic Query Syntax.md
@@ -100,6 +100,6 @@ However, if a query has no `arguments` or `directives` (we will discuss directiv
 
 ```
 
-[Previous](/1. What is GraphQL.md) - What is GraphQL
+[Previous](1.%20What%20is%20GraphQL.md) - What is GraphQL
 
-[Next](/2. Basic Query Syntax.md) - Querying with Field Aliases and Fragments
+[Next](2.%20Basic%20Query%20Syntax.md) - Querying with Field Aliases and Fragments

--- a/3. Querying with Field Aliases and Fragments.md
+++ b/3. Querying with Field Aliases and Fragments.md
@@ -163,3 +163,6 @@ query inlineFragmentTyping {
 
 
 There are other ways to conditionally modify a query. `Directive` plays the key role in that and we are going to talk about them in the next part.
+
+[Previous](http://google.com) - Basic Query Syntax
+[Next](http://google.com) - Querying with Directives

--- a/3. Querying with Field Aliases and Fragments.md
+++ b/3. Querying with Field Aliases and Fragments.md
@@ -165,4 +165,5 @@ query inlineFragmentTyping {
 There are other ways to conditionally modify a query. `Directive` plays the key role in that and we are going to talk about them in the next part.
 
 [Previous](http://google.com) - Basic Query Syntax
+
 [Next](http://google.com) - Querying with Directives

--- a/3. Querying with Field Aliases and Fragments.md
+++ b/3. Querying with Field Aliases and Fragments.md
@@ -164,6 +164,6 @@ query inlineFragmentTyping {
 
 There are other ways to conditionally modify a query. `Directive` plays the key role in that and we are going to talk about them in the next part.
 
-[Previous](http://google.com) - Basic Query Syntax
+[Previous](2.%20Basic%20Query%20Syntax.md) - Basic Query Syntax
 
-[Next](http://google.com) - Querying with Directives
+[Next](4.%20Querying%20with%20Directives.md) - Querying with Directives

--- a/4. Querying with Directives.md
+++ b/4. Querying with Directives.md
@@ -95,4 +95,5 @@ This example is here just to show how to post a GraphQL query programmatically i
 Now what about the GraphQL server that'll process the query? We haven't said anything about how to write a GraphQL server yet. Let's start that in the next part.
 
 [Previous](http://google.com) - Querying with Field Aliases and Fragments
+
 [Next](http://google.com) - On the Server-Side - Creating Your First Schema

--- a/4. Querying with Directives.md
+++ b/4. Querying with Directives.md
@@ -93,3 +93,6 @@ request.post(SERVER_URL, {
 This example is here just to show how to post a GraphQL query programmatically in nodejs. Of course the same can be achieved with `curl`, `Postman`, `httpie`, `XMLHttpRequest` or the modern `fetch` API in browsers. If you are using React (you probably are using that), Relay will take care of it.
 
 Now what about the GraphQL server that'll process the query? We haven't said anything about how to write a GraphQL server yet. Let's start that in the next part.
+
+[Previous](http://google.com) - Querying with Field Aliases and Fragments
+[Next](http://google.com) - On the Server-Side - Creating Your First Schema

--- a/4. Querying with Directives.md
+++ b/4. Querying with Directives.md
@@ -94,6 +94,6 @@ This example is here just to show how to post a GraphQL query programmatically i
 
 Now what about the GraphQL server that'll process the query? We haven't said anything about how to write a GraphQL server yet. Let's start that in the next part.
 
-[Previous](http://google.com) - Querying with Field Aliases and Fragments
+[Previous](3.%20Querying%20with%20Field%20Aliases%20and%20Fragments.md) - Querying with Field Aliases and Fragments
 
-[Next](http://google.com) - On the Server-Side - Creating Your First Schema
+[Next](5.%20On%20the%20Server-Side%20-%20Creating%20Your%20First%20Schema.md) - On the Server-Side - Creating Your First Schema

--- a/5. On the Server-Side - Creating Your First Schema.md
+++ b/5. On the Server-Side - Creating Your First Schema.md
@@ -98,6 +98,6 @@ graphql(schema, query).then((result) => {
 
 If you are using server-side MVC frameworks like Ruby on Rails, Laravel or SailsJS, you are probably getting a hint here that the coming days are going to be a lot different with GraphQL. The `V` in MVC has already gone from the server-side in API only use cases. What's next? I can only speculate there will be rudimentary routing for our API servers, as we won't have a bunch of routes but a single endpoint. The schema will do a lot of validation for us, a lot of authentication & authorization will be on middleware layers, as they are now. The `resolve` function of the fields will probably take a lot of responsibility from controllers. The only least affected areas might be the models/ORM layer. Or maybe GraphQL will co-exists with REST and pre-dominant MVC style server-side architecture for a long time. I don't know. But I'm excited to embrace what's coming in the near future!
 
-[Previous](http://google.com) - Querying with Directives
+[Previous](4.%20Querying%20with%20Directives.md) - Querying with Directives
 
-[Next](http://google.com) - A Working GraphQL Server in Nodejs
+[Next](6.%20A%20Working%20GraphQL%20Server%20in%20Nodejs.md) - A Working GraphQL Server in Nodejs

--- a/5. On the Server-Side - Creating Your First Schema.md
+++ b/5. On the Server-Side - Creating Your First Schema.md
@@ -99,4 +99,5 @@ graphql(schema, query).then((result) => {
 If you are using server-side MVC frameworks like Ruby on Rails, Laravel or SailsJS, you are probably getting a hint here that the coming days are going to be a lot different with GraphQL. The `V` in MVC has already gone from the server-side in API only use cases. What's next? I can only speculate there will be rudimentary routing for our API servers, as we won't have a bunch of routes but a single endpoint. The schema will do a lot of validation for us, a lot of authentication & authorization will be on middleware layers, as they are now. The `resolve` function of the fields will probably take a lot of responsibility from controllers. The only least affected areas might be the models/ORM layer. Or maybe GraphQL will co-exists with REST and pre-dominant MVC style server-side architecture for a long time. I don't know. But I'm excited to embrace what's coming in the near future!
 
 [Previous](http://google.com) - Querying with Directives
+
 [Next](http://google.com) - A Working GraphQL Server in Nodejs

--- a/5. On the Server-Side - Creating Your First Schema.md
+++ b/5. On the Server-Side - Creating Your First Schema.md
@@ -97,3 +97,6 @@ graphql(schema, query).then((result) => {
 > Have you noticed that we are using double-quotes in `hello (greet: "mehdi")` in our query? That's because using single-quotes in `GraphQLString` type parameters is invalid. Tada!
 
 If you are using server-side MVC frameworks like Ruby on Rails, Laravel or SailsJS, you are probably getting a hint here that the coming days are going to be a lot different with GraphQL. The `V` in MVC has already gone from the server-side in API only use cases. What's next? I can only speculate there will be rudimentary routing for our API servers, as we won't have a bunch of routes but a single endpoint. The schema will do a lot of validation for us, a lot of authentication & authorization will be on middleware layers, as they are now. The `resolve` function of the fields will probably take a lot of responsibility from controllers. The only least affected areas might be the models/ORM layer. Or maybe GraphQL will co-exists with REST and pre-dominant MVC style server-side architecture for a long time. I don't know. But I'm excited to embrace what's coming in the near future!
+
+[Previous](http://google.com) - Querying with Directives
+[Next](http://google.com) - A Working GraphQL Server in Nodejs

--- a/6. A Working GraphQL Server in Nodejs.md
+++ b/6. A Working GraphQL Server in Nodejs.md
@@ -108,6 +108,6 @@ curl -XPOST -d '{contributor (id: "1")}' http://localhost:8080/
 
 If you got `{"data":{"contributor":"leebyron"}}` in return, congratulations for making it this far!
 
-[Previous](http://google.com) - On the Server-Side - Creating Your First Schema
+[Previous](5.%20A%20Working%20GraphQL%20Server%20in%20Nodejs.md) - On the Server-Side - Creating Your First Schema
 
-[Next](http://google.com) - Deep Dive into GraphQL Type System
+[Next](7.%20Deep%20Dive%20into%20GraphQL%20Type%20System.md) - Deep Dive into GraphQL Type System

--- a/6. A Working GraphQL Server in Nodejs.md
+++ b/6. A Working GraphQL Server in Nodejs.md
@@ -107,3 +107,6 @@ curl -XPOST -d '{contributor (id: "1")}' http://localhost:8080/
 ```
 
 If you got `{"data":{"contributor":"leebyron"}}` in return, congratulations for making it this far!
+
+[Previous](http://google.com) - On the Server-Side - Creating Your First Schema
+[Next](http://google.com) - Deep Dive into GraphQL Type System

--- a/6. A Working GraphQL Server in Nodejs.md
+++ b/6. A Working GraphQL Server in Nodejs.md
@@ -108,6 +108,6 @@ curl -XPOST -d '{contributor (id: "1")}' http://localhost:8080/
 
 If you got `{"data":{"contributor":"leebyron"}}` in return, congratulations for making it this far!
 
-[Previous](5.%20A%20Working%20GraphQL%20Server%20in%20Nodejs.md) - On the Server-Side - Creating Your First Schema
+[Previous](5.%20On%20the%20Server-Side%20-%20Creating%20Your%20First%20Schema.md) - On the Server-Side - Creating Your First Schema
 
 [Next](7.%20Deep%20Dive%20into%20GraphQL%20Type%20System.md) - Deep Dive into GraphQL Type System

--- a/6. A Working GraphQL Server in Nodejs.md
+++ b/6. A Working GraphQL Server in Nodejs.md
@@ -109,4 +109,5 @@ curl -XPOST -d '{contributor (id: "1")}' http://localhost:8080/
 If you got `{"data":{"contributor":"leebyron"}}` in return, congratulations for making it this far!
 
 [Previous](http://google.com) - On the Server-Side - Creating Your First Schema
+
 [Next](http://google.com) - Deep Dive into GraphQL Type System

--- a/7. Deep Dive into GraphQL Type System.md
+++ b/7. Deep Dive into GraphQL Type System.md
@@ -450,3 +450,6 @@ graphql(schema, query).then((result) => {
 ```
 
 Now you can define more custom scalar types using `ValidateStringType` function. *Thanks [pyros2097](https://github.com/pyros2097) for the suggestion and `ValidateStringType` snippet!*
+
+[Previous](http://google.com) - A Working GraphQL Server in Nodejs
+[Next](http://google.com) - Mutations

--- a/7. Deep Dive into GraphQL Type System.md
+++ b/7. Deep Dive into GraphQL Type System.md
@@ -451,6 +451,6 @@ graphql(schema, query).then((result) => {
 
 Now you can define more custom scalar types using `ValidateStringType` function. *Thanks [pyros2097](https://github.com/pyros2097) for the suggestion and `ValidateStringType` snippet!*
 
-[Previous](http://google.com) - A Working GraphQL Server in Nodejs
+[Previous](6.%20A%20Working%20GraphQL%20Server%20in%20Nodejs.md) - A Working GraphQL Server in Nodejs
 
-[Next](http://google.com) - Mutations
+[Next](8.%20Mutations.md) - Mutations

--- a/7. Deep Dive into GraphQL Type System.md
+++ b/7. Deep Dive into GraphQL Type System.md
@@ -452,4 +452,5 @@ graphql(schema, query).then((result) => {
 Now you can define more custom scalar types using `ValidateStringType` function. *Thanks [pyros2097](https://github.com/pyros2097) for the suggestion and `ValidateStringType` snippet!*
 
 [Previous](http://google.com) - A Working GraphQL Server in Nodejs
+
 [Next](http://google.com) - Mutations

--- a/8. Mutations.md
+++ b/8. Mutations.md
@@ -92,4 +92,5 @@ curl -XPOST -d 'mutation UpdateContributorUsername {updateContributor (id: "5", 
 One important difference between mutation and query operations is, if you post multiple mutations together, they are processed serially in order to ensure data integrity, whereas independent queries are processed concurrently by the GraphQL executor.
 
 [Previous](http://google.com) - Deep Dive into GraphQL Type System
+
 [Next](http://google.com) - Instrospection

--- a/8. Mutations.md
+++ b/8. Mutations.md
@@ -90,3 +90,6 @@ curl -XPOST -d 'mutation UpdateContributorUsername {updateContributor (id: "5", 
 ```
 
 One important difference between mutation and query operations is, if you post multiple mutations together, they are processed serially in order to ensure data integrity, whereas independent queries are processed concurrently by the GraphQL executor.
+
+[Previous](http://google.com) - Deep Dive into GraphQL Type System
+[Next](http://google.com) - Instrospection

--- a/8. Mutations.md
+++ b/8. Mutations.md
@@ -91,6 +91,6 @@ curl -XPOST -d 'mutation UpdateContributorUsername {updateContributor (id: "5", 
 
 One important difference between mutation and query operations is, if you post multiple mutations together, they are processed serially in order to ensure data integrity, whereas independent queries are processed concurrently by the GraphQL executor.
 
-[Previous](http://google.com) - Deep Dive into GraphQL Type System
+[Previous](7.%20Deep%20Dive%20into%20GraphQL%20Type%20System.md) - Deep Dive into GraphQL Type System
 
-[Next](http://google.com) - Instrospection
+[Next](9.%20Introspection.md) - Instrospection

--- a/9. Introspection.md
+++ b/9. Introspection.md
@@ -3,3 +3,6 @@
 It's often useful to ask a GraphQL schema for information about what queries it supports. GraphQL allows us to do so using the introspection system.
 
 TBD.
+
+[Previous](http://google.com) - Mutations
+<strike>Next</strike>

--- a/9. Introspection.md
+++ b/9. Introspection.md
@@ -5,4 +5,5 @@ It's often useful to ask a GraphQL schema for information about what queries it 
 TBD.
 
 [Previous](http://google.com) - Mutations
+
 <strike>Next</strike>

--- a/9. Introspection.md
+++ b/9. Introspection.md
@@ -4,6 +4,6 @@ It's often useful to ask a GraphQL schema for information about what queries it 
 
 TBD.
 
-[Previous](http://google.com) - Mutations
+[Previous](8.%20Mutations.md) - Mutations
 
 <strike>Next</strike>


### PR DESCRIPTION
# Description
Returning to the homepage just for selecting another file is boring, so I decided to add some relative links for each part to redirect the user to the previous or the next file. It works like a navigation.

# Results
This is what it looks like.

![graphql](https://user-images.githubusercontent.com/3977337/30035617-803fce56-9182-11e7-884f-254bba73760a.gif)
